### PR TITLE
Enemy system overhaul

### DIFF
--- a/Assets/Prefabs/Enemies/EnemyAI_Charger.prefab
+++ b/Assets/Prefabs/Enemies/EnemyAI_Charger.prefab
@@ -180,10 +180,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6a7bf33d73132c439ecefca2620c8b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAI_Charger
-  baseMaxHealth: 40
-  baseMoveSpeed: 1.8
+  baseMaxHealth: 20
+  baseMoveSpeed: 3
   baseDamage: 20
-  baseXPValue: 8
+  baseXPValue: 2
+  hpScalesWithLevel: 0
   xpOrbPrefab: {fileID: 3607475533658753199, guid: a7d67cb173a2bf9409f147b6d2e5854f, type: 3}
   spriteRenderer: {fileID: 0}
   damageFlashColor: {r: 1, g: 0, b: 0, a: 1}

--- a/Assets/Prefabs/Enemies/EnemyAI_Elite.prefab
+++ b/Assets/Prefabs/Enemies/EnemyAI_Elite.prefab
@@ -184,6 +184,7 @@ MonoBehaviour:
   baseMoveSpeed: 0.7
   baseDamage: 40
   baseXPValue: 50
+  hpScalesWithLevel: 1
   xpOrbPrefab: {fileID: 3607475533658753199, guid: a7d67cb173a2bf9409f147b6d2e5854f, type: 3}
   spriteRenderer: {fileID: 0}
   damageFlashColor: {r: 1, g: 0, b: 0, a: 1}

--- a/Assets/Prefabs/Enemies/EnemyAI_Projector.prefab
+++ b/Assets/Prefabs/Enemies/EnemyAI_Projector.prefab
@@ -180,10 +180,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8eecc9bf6f936ad46918f6490c4fd3e4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAI_Projector
-  baseMaxHealth: 25
-  baseMoveSpeed: 1.2
-  baseDamage: 8
-  baseXPValue: 6
+  baseMaxHealth: 8
+  baseMoveSpeed: 5.5
+  baseDamage: 5
+  baseXPValue: 2
+  hpScalesWithLevel: 0
   xpOrbPrefab: {fileID: 3607475533658753199, guid: a7d67cb173a2bf9409f147b6d2e5854f, type: 3}
   spriteRenderer: {fileID: 0}
   damageFlashColor: {r: 1, g: 0, b: 0, a: 1}
@@ -196,7 +197,7 @@ MonoBehaviour:
   preferredRange: 7
   fireRate: 1.5
   projectileSpeed: 5
-  projectileDamage: 8
+  projectileDamage: 5
 --- !u!58 &-8659370905885529700
 CircleCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemies/EnemyAI_Projector.prefab
+++ b/Assets/Prefabs/Enemies/EnemyAI_Projector.prefab
@@ -181,7 +181,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAI_Projector
   baseMaxHealth: 8
-  baseMoveSpeed: 5.5
+  baseMoveSpeed: 3
   baseDamage: 5
   baseXPValue: 2
   hpScalesWithLevel: 0

--- a/Assets/Prefabs/Enemies/EnemyAI_Swarmer.prefab
+++ b/Assets/Prefabs/Enemies/EnemyAI_Swarmer.prefab
@@ -181,7 +181,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAI_Swarmer
   baseMaxHealth: 5
-  baseMoveSpeed: 5
+  baseMoveSpeed: 3
   baseDamage: 5
   baseXPValue: 1
   hpScalesWithLevel: 0

--- a/Assets/Prefabs/Enemies/EnemyAI_Swarmer.prefab
+++ b/Assets/Prefabs/Enemies/EnemyAI_Swarmer.prefab
@@ -180,10 +180,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60cb73c9f5e963e46bbe5a68fff87b28, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAI_Swarmer
-  baseMaxHealth: 8
-  baseMoveSpeed: 2.5
+  baseMaxHealth: 5
+  baseMoveSpeed: 5
   baseDamage: 5
-  baseXPValue: 3
+  baseXPValue: 1
+  hpScalesWithLevel: 0
   xpOrbPrefab: {fileID: 3607475533658753199, guid: a7d67cb173a2bf9409f147b6d2e5854f, type: 3}
   spriteRenderer: {fileID: 0}
   damageFlashColor: {r: 1, g: 0, b: 0, a: 1}

--- a/Assets/Prefabs/Enemies/EnemyAI_Tank.prefab
+++ b/Assets/Prefabs/Enemies/EnemyAI_Tank.prefab
@@ -180,7 +180,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 506ce27f2cc85cb49815dbfe6ac27d0d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAI_Tank
-  baseMaxHealth: 100
+  baseMaxHealth: 250
   baseMoveSpeed: 1
   baseDamage: 40
   baseXPValue: 10

--- a/Assets/Prefabs/Enemies/EnemyAI_Tank.prefab
+++ b/Assets/Prefabs/Enemies/EnemyAI_Tank.prefab
@@ -180,10 +180,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 506ce27f2cc85cb49815dbfe6ac27d0d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAI_Tank
-  baseMaxHealth: 150
-  baseMoveSpeed: 0.8
-  baseDamage: 25
-  baseXPValue: 15
+  baseMaxHealth: 100
+  baseMoveSpeed: 1
+  baseDamage: 40
+  baseXPValue: 10
+  hpScalesWithLevel: 0
   xpOrbPrefab: {fileID: 3607475533658753199, guid: a7d67cb173a2bf9409f147b6d2e5854f, type: 3}
   spriteRenderer: {fileID: 0}
   damageFlashColor: {r: 1, g: 0, b: 0, a: 1}

--- a/Assets/Prefabs/Enemies/Enemy_Fodder.prefab
+++ b/Assets/Prefabs/Enemies/Enemy_Fodder.prefab
@@ -181,7 +181,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAI_Fodder
   baseMaxHealth: 10
-  baseMoveSpeed: 2.8
+  baseMoveSpeed: 2
   baseDamage: 10
   baseXPValue: 1
   hpScalesWithLevel: 0

--- a/Assets/Prefabs/Enemies/Enemy_Fodder.prefab
+++ b/Assets/Prefabs/Enemies/Enemy_Fodder.prefab
@@ -180,10 +180,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f5f1817b1933332409dcc845a02b690b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAI_Fodder
-  baseMaxHealth: 20
-  baseMoveSpeed: 1.5
+  baseMaxHealth: 10
+  baseMoveSpeed: 2.8
   baseDamage: 10
-  baseXPValue: 5
+  baseXPValue: 1
+  hpScalesWithLevel: 0
   xpOrbPrefab: {fileID: 3607475533658753199, guid: a7d67cb173a2bf9409f147b6d2e5854f, type: 3}
   spriteRenderer: {fileID: 0}
   damageFlashColor: {r: 1, g: 0, b: 0, a: 1}

--- a/Assets/Prefabs/Enemies/WaveTable_Main.asset
+++ b/Assets/Prefabs/Enemies/WaveTable_Main.asset
@@ -77,13 +77,15 @@ MonoBehaviour:
   - label: Minute 8
     enemies:
     - prefab: {fileID: 9123483832259158770, guid: 0fbe6e6071273204588efb2cbc80f8bc, type: 3}
-      minimumAlive: 30
+      minimumAlive: 25
     - prefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
-      minimumAlive: 20
+      minimumAlive: 15
     - prefab: {fileID: 3294526708094241870, guid: 1ffdbee5b5aa0f54eb3687f314c4eedd, type: 3}
-      minimumAlive: 20
+      minimumAlive: 15
     - prefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
       minimumAlive: 30
+    - prefab: {fileID: 733373330187717797, guid: 0b99695fe1a0b274ebe68263dbe60776, type: 3}
+      minimumAlive: 2
     spawnInterval: 0.8
   - label: Minute 9
     enemies:
@@ -112,7 +114,7 @@ MonoBehaviour:
     triggerTime: 360
     enemyPrefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
     enemyCount: 10
-    ringRadius: 0
+    ringRadius: 7
     duration: 0
     triggered: 0
   - label: Big Swarm

--- a/Assets/Prefabs/Enemies/WaveTable_Main.asset
+++ b/Assets/Prefabs/Enemies/WaveTable_Main.asset
@@ -12,164 +12,114 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 00a4ab5a8ec997047b148914e6b3a48e, type: 3}
   m_Name: WaveTable_Main
   m_EditorClassIdentifier: Assembly-CSharp::WaveTable
-  startEnemyCap: 40
-  maxEnemyCap: 400
-  capRampTime: 900
-  baseSpawnInterval: 1.8
-  minSpawnInterval: 0.2
-  intervalRampTime: 600
-  hpScaleTime: 600
-  speedScaleFactor: 0.3
-  speedScaleTime: 600
-  damageScaleTime: 480
-  wallTriggerKillRate: 8
-  wallSpawnCooldown: 20
+  hardCap: 300
   despawnDistance: 22
   teleportScanInterval: 2
-  windows:
-  - startTime: 0
-    endTime: 60
-    label: 0-1min
-    rules:
-    - enemyPrefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
-      spawnWeight: 100
-      spawnInClusters: 1
-      minClusterSize: 3
-      maxClusterSize: 5
-      clusterSpread: 1.5
-  - startTime: 60
-    endTime: 180
-    label: 1-3min
-    rules:
-    - enemyPrefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
-      spawnWeight: 70
-      spawnInClusters: 1
-      minClusterSize: 3
-      maxClusterSize: 6
-      clusterSpread: 1.5
-    - enemyPrefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
-      spawnWeight: 30
-      spawnInClusters: 1
-      minClusterSize: 8
-      maxClusterSize: 14
-      clusterSpread: 2.5
-  - startTime: 180
-    endTime: 300
-    label: 3-5min
-    rules:
-    - enemyPrefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
-      spawnWeight: 50
-      spawnInClusters: 1
-      minClusterSize: 4
-      maxClusterSize: 8
-      clusterSpread: 1.5
-    - enemyPrefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
-      spawnWeight: 30
-      spawnInClusters: 1
-      minClusterSize: 10
-      maxClusterSize: 18
-      clusterSpread: 2.5
-    - enemyPrefab: {fileID: 3294526708094241870, guid: 1ffdbee5b5aa0f54eb3687f314c4eedd, type: 3}
-      spawnWeight: 20
-      spawnInClusters: 0
-      minClusterSize: 0
-      maxClusterSize: 0
-      clusterSpread: 0
-  - startTime: 300
-    endTime: 480
-    label: 5-8min
-    rules:
-    - enemyPrefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
-      spawnWeight: 40
-      spawnInClusters: 1
-      minClusterSize: 4
-      maxClusterSize: 8
-      clusterSpread: 0
-    - enemyPrefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
-      spawnWeight: 25
-      spawnInClusters: 1
-      minClusterSize: 10
-      maxClusterSize: 18
-      clusterSpread: 0
-    - enemyPrefab: {fileID: 3294526708094241870, guid: 1ffdbee5b5aa0f54eb3687f314c4eedd, type: 3}
-      spawnWeight: 20
-      spawnInClusters: 0
-      minClusterSize: 0
-      maxClusterSize: 0
-      clusterSpread: 0
-    - enemyPrefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
-      spawnWeight: 15
-      spawnInClusters: 0
-      minClusterSize: 0
-      maxClusterSize: 0
-      clusterSpread: 0
-  - startTime: 480
-    endTime: 0
-    label: 8min+
-    rules:
-    - enemyPrefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
-      spawnWeight: 30
-      spawnInClusters: 1
-      minClusterSize: 4
-      maxClusterSize: 8
-      clusterSpread: 0
-    - enemyPrefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
-      spawnWeight: 25
-      spawnInClusters: 1
-      minClusterSize: 12
-      maxClusterSize: 20
-      clusterSpread: 0
-    - enemyPrefab: {fileID: 3294526708094241870, guid: 1ffdbee5b5aa0f54eb3687f314c4eedd, type: 3}
-      spawnWeight: 20
-      spawnInClusters: 0
-      minClusterSize: 0
-      maxClusterSize: 0
-      clusterSpread: 0
-    - enemyPrefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
-      spawnWeight: 15
-      spawnInClusters: 0
-      minClusterSize: 0
-      maxClusterSize: 0
-      clusterSpread: 0
-    - enemyPrefab: {fileID: 9123483832259158770, guid: 0fbe6e6071273204588efb2cbc80f8bc, type: 3}
-      spawnWeight: 10
-      spawnInClusters: 0
-      minClusterSize: 0
-      maxClusterSize: 0
-      clusterSpread: 0
-  specialEvents:
-  - eventType: 0
-    triggerTime: 90
-    duration: 25
+  waves:
+  - label: Minute 0
+    enemies:
+    - prefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
+      minimumAlive: 15
+    spawnInterval: 1
+  - label: Minute 1
+    enemies:
+    - prefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
+      minimumAlive: 20
+    - prefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
+      minimumAlive: 10
+    spawnInterval: 1
+  - label: Minute 2
+    enemies:
+    - prefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
+      minimumAlive: 25
+    - prefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
+      minimumAlive: 15
+    spawnInterval: 1
+  - label: Minute 3
+    enemies:
+    - prefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
+      minimumAlive: 25
+    - prefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
+      minimumAlive: 20
+    spawnInterval: 1
+  - label: Minute 4
+    enemies:
+    - prefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
+      minimumAlive: 25
+    - prefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
+      minimumAlive: 25
+    spawnInterval: 1
+  - label: Minute 5
+    enemies:
+    - prefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
+      minimumAlive: 30
+    - prefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
+      minimumAlive: 10
+    spawnInterval: 0.9
+  - label: Minute 6
+    enemies:
+    - prefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
+      minimumAlive: 30
+    - prefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
+      minimumAlive: 15
+    - prefab: {fileID: 9123483832259158770, guid: 0fbe6e6071273204588efb2cbc80f8bc, type: 3}
+      minimumAlive: 15
+    spawnInterval: 0.9
+  - label: Minute 7
+    enemies:
+    - prefab: {fileID: 9123483832259158770, guid: 0fbe6e6071273204588efb2cbc80f8bc, type: 3}
+      minimumAlive: 30
+    - prefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
+      minimumAlive: 20
+    - prefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
+      minimumAlive: 20
+    spawnInterval: 0.9
+  - label: Minute 8
+    enemies:
+    - prefab: {fileID: 9123483832259158770, guid: 0fbe6e6071273204588efb2cbc80f8bc, type: 3}
+      minimumAlive: 30
+    - prefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
+      minimumAlive: 20
+    - prefab: {fileID: 3294526708094241870, guid: 1ffdbee5b5aa0f54eb3687f314c4eedd, type: 3}
+      minimumAlive: 20
+    - prefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
+      minimumAlive: 30
+    spawnInterval: 0.8
+  - label: Minute 9
+    enemies:
+    - prefab: {fileID: 4168022889002980508, guid: 75402789e29c0ce4bac233cbef81f5a1, type: 3}
+      minimumAlive: 30
+    - prefab: {fileID: 3294526708094241870, guid: 1ffdbee5b5aa0f54eb3687f314c4eedd, type: 3}
+      minimumAlive: 20
+    - prefab: {fileID: 9123483832259158770, guid: 0fbe6e6071273204588efb2cbc80f8bc, type: 3}
+      minimumAlive: 20
+    - prefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
+      minimumAlive: 30
+    - prefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
+      minimumAlive: 20
+    spawnInterval: 0.8
+  mapEvents:
+  - label: First Swarm
+    eventType: 0
+    triggerTime: 150
     enemyPrefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
-    enemyCount: 80
+    enemyCount: 40
     ringRadius: 0
-    triggered: 1
-  - eventType: 3
-    triggerTime: 240
-    duration: 5
-    enemyPrefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
-    enemyCount: 12
-    ringRadius: 7
-    triggered: 1
-  - eventType: 0
-    triggerTime: 420
-    duration: 30
-    enemyPrefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
-    enemyCount: 120
-    ringRadius: 0
-    triggered: 0
-  - eventType: 1
-    triggerTime: 600
     duration: 20
-    enemyPrefab: {fileID: 733373330187717797, guid: 0b99695fe1a0b274ebe68263dbe60776, type: 3}
-    enemyCount: 8
-    ringRadius: 8
     triggered: 0
-  - eventType: 2
-    triggerTime: 300
-    duration: 60
-    enemyPrefab: {fileID: 733373330187717797, guid: 0b99695fe1a0b274ebe68263dbe60776, type: 3}
-    enemyCount: 1
+  - label: Wall
+    eventType: 1
+    triggerTime: 360
+    enemyPrefab: {fileID: 6424925252929009345, guid: 1dbdae990bf5e694fbe6570d3d67588f, type: 3}
+    enemyCount: 10
     ringRadius: 0
+    duration: 0
+    triggered: 0
+  - label: Big Swarm
+    eventType: 0
+    triggerTime: 540
+    enemyPrefab: {fileID: 8885661568427781882, guid: 69a029533d8714d4e9d055c2f7274f52, type: 3}
+    enemyCount: 60
+    ringRadius: 0
+    duration: 25
     triggered: 0

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -2061,7 +2061,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::AudioManager
   mainMenuMusic: {fileID: 8300000, guid: 8f9d7610aa0fe0b4ebebb998c9d56c97, type: 3}
   gameplayMusic: {fileID: 8300000, guid: b0350fa472bb65b43b3950fc09d5792f, type: 3}
-  musicVolume: 0.1
+  musicVolume: 0.07
   hoverSound: {fileID: 8300000, guid: 9440c85853e3d104895a51e7e7005fa6, type: 3}
   clickSound: {fileID: 8300000, guid: 806e2bb1c1db65d488067fd105217df7, type: 3}
   sfxVolume: 0.15

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -568,6 +568,7 @@ GameObject:
   - component: {fileID: 413782751}
   - component: {fileID: 413782750}
   - component: {fileID: 413782752}
+  - component: {fileID: 413782753}
   m_Layer: 5
   m_Name: ArrowLeft
   m_TagString: Untagged
@@ -688,6 +689,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &413782753
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 413782748}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ece6c40a95e43a249a8caa6f7be5109e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MenuButtonSound
 --- !u!1 &496985992
 GameObject:
   m_ObjectHideFlags: 0
@@ -775,6 +788,7 @@ GameObject:
   - component: {fileID: 714188818}
   - component: {fileID: 714188817}
   - component: {fileID: 714188816}
+  - component: {fileID: 714188820}
   m_Layer: 5
   m_Name: HelpButton
   m_TagString: Untagged
@@ -910,6 +924,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 714188814}
   m_CullTransparentMesh: 1
+--- !u!114 &714188820
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 714188814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ece6c40a95e43a249a8caa6f7be5109e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MenuButtonSound
 --- !u!1 &1039237643
 GameObject:
   m_ObjectHideFlags: 0
@@ -1266,6 +1292,7 @@ GameObject:
   - component: {fileID: 1480110899}
   - component: {fileID: 1480110898}
   - component: {fileID: 1480110897}
+  - component: {fileID: 1480110901}
   m_Layer: 5
   m_Name: OptionsButton
   m_TagString: Untagged
@@ -1401,6 +1428,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1480110895}
   m_CullTransparentMesh: 1
+--- !u!114 &1480110901
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480110895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ece6c40a95e43a249a8caa6f7be5109e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MenuButtonSound
 --- !u!1 &1546627699
 GameObject:
   m_ObjectHideFlags: 0
@@ -1596,6 +1635,7 @@ GameObject:
   - component: {fileID: 1592784016}
   - component: {fileID: 1592784015}
   - component: {fileID: 1592784014}
+  - component: {fileID: 1592784018}
   m_Layer: 5
   m_Name: QuitButton
   m_TagString: Untagged
@@ -1731,6 +1771,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1592784012}
   m_CullTransparentMesh: 1
+--- !u!114 &1592784018
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1592784012}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ece6c40a95e43a249a8caa6f7be5109e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MenuButtonSound
 --- !u!1 &1778087612
 GameObject:
   m_ObjectHideFlags: 0
@@ -1845,6 +1897,7 @@ GameObject:
   - component: {fileID: 1795704316}
   - component: {fileID: 1795704315}
   - component: {fileID: 1795704314}
+  - component: {fileID: 1795704318}
   m_Layer: 5
   m_Name: ArrowRight
   m_TagString: Untagged
@@ -1965,6 +2018,18 @@ RectTransform:
   m_AnchoredPosition: {x: 220, y: 0}
   m_SizeDelta: {x: 78, y: 98}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1795704318
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1795704313}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ece6c40a95e43a249a8caa6f7be5109e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MenuButtonSound
 --- !u!1 &1918536295
 GameObject:
   m_ObjectHideFlags: 0
@@ -1996,7 +2061,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::AudioManager
   mainMenuMusic: {fileID: 8300000, guid: 8f9d7610aa0fe0b4ebebb998c9d56c97, type: 3}
   gameplayMusic: {fileID: 8300000, guid: b0350fa472bb65b43b3950fc09d5792f, type: 3}
-  musicVolume: 0.2
+  musicVolume: 0.1
   hoverSound: {fileID: 8300000, guid: 9440c85853e3d104895a51e7e7005fa6, type: 3}
   clickSound: {fileID: 8300000, guid: 806e2bb1c1db65d488067fd105217df7, type: 3}
   sfxVolume: 0.15
@@ -2107,6 +2172,7 @@ GameObject:
   - component: {fileID: 2036721261}
   - component: {fileID: 2036721260}
   - component: {fileID: 2036721259}
+  - component: {fileID: 2036721263}
   m_Layer: 5
   m_Name: PlayButton
   m_TagString: Untagged
@@ -2242,6 +2308,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2036721257}
   m_CullTransparentMesh: 1
+--- !u!114 &2036721263
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2036721257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ece6c40a95e43a249a8caa6f7be5109e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MenuButtonSound
 --- !u!1 &2118884722
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1965,6 +1965,58 @@ RectTransform:
   m_AnchoredPosition: {x: 220, y: 0}
   m_SizeDelta: {x: 78, y: 98}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1918536295
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1918536297}
+  - component: {fileID: 1918536296}
+  m_Layer: 0
+  m_Name: AudioManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1918536296
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1918536295}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2681f1d957a8354cb2d9aa7b5822bd0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::AudioManager
+  mainMenuMusic: {fileID: 8300000, guid: 8f9d7610aa0fe0b4ebebb998c9d56c97, type: 3}
+  gameplayMusic: {fileID: 8300000, guid: b0350fa472bb65b43b3950fc09d5792f, type: 3}
+  musicVolume: 0.2
+  hoverSound: {fileID: 8300000, guid: 9440c85853e3d104895a51e7e7005fa6, type: 3}
+  clickSound: {fileID: 8300000, guid: 806e2bb1c1db65d488067fd105217df7, type: 3}
+  sfxVolume: 0.15
+  mainMenuSceneName: MainMenu
+  gameSceneName: Scene1
+--- !u!4 &1918536297
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1918536295}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 11.0231, y: -11.26866, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1993646055
 GameObject:
   m_ObjectHideFlags: 0
@@ -2416,3 +2468,4 @@ SceneRoots:
   - {fileID: 220468671}
   - {fileID: 1546627703}
   - {fileID: 1173808553}
+  - {fileID: 1918536297}

--- a/Assets/Scripts/AuraField.cs
+++ b/Assets/Scripts/AuraField.cs
@@ -2,36 +2,31 @@ using UnityEngine;
 
 public class AuraField : MonoBehaviour
 {
-    private float damage = 10f;
-    private float damageInterval = 1f;
-    private float radius = 1.2f;
-    private float timer = 0f;
+    private float damageMultiplier = 0.5f;
+    private float damageInterval   = 1.0f;
+    private float radius           = 1.2f;
+    private float timer            = 0f;
     private GameObject auraVisual;
 
-    void Start()
-    {
-        CreateVisual();
-    }
+    void Start() => CreateVisual();
 
     void Update()
     {
         timer += Time.deltaTime;
-        if (timer >= damageInterval)
-        {
-            timer = 0f;
-            DamageNearbyEnemies();
-        }
+        if (timer >= damageInterval) { timer = 0f; DamageNearbyEnemies(); }
     }
 
     public void LevelUp(int level)
     {
-        damage = 10f + (level - 1) * 8f;
-        radius = 1.2f + (level - 1) * 0.25f;
+        damageMultiplier = 0.5f  + (level - 1) * 0.15f;  // 0.5, 0.65, 0.8, 0.95, 1.1
+        radius           = 1.2f  + (level - 1) * 0.3f;   // 1.2, 1.5, 1.8, 2.1, 2.4
+        damageInterval   = Mathf.Max(0.5f, 1.0f - (level - 1) * 0.1f); // ticks faster with level
         UpdateVisual();
     }
 
     void DamageNearbyEnemies()
     {
+        float damage = PlayerStats.Instance.damage * damageMultiplier;
         Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, radius);
         foreach (Collider2D hit in hits)
         {
@@ -48,10 +43,9 @@ public class AuraField : MonoBehaviour
         auraVisual.transform.localPosition = Vector3.zero;
 
         SpriteRenderer sr = auraVisual.AddComponent<SpriteRenderer>();
-        sr.sprite = SpriteHelper.CreateCircle(128);
-        sr.color = new Color(0.5f, 0f, 1f, 0.25f);
+        sr.sprite       = SpriteHelper.CreateCircle(128);
+        sr.color        = new Color(0.5f, 0f, 1f, 0.25f);
         sr.sortingOrder = 1;
-
         UpdateVisual();
     }
 

--- a/Assets/Scripts/BaseEnemy.cs
+++ b/Assets/Scripts/BaseEnemy.cs
@@ -1,17 +1,17 @@
 using UnityEngine;
 
-/// <summary>
-/// Replaces both EnemyHealth and EnemyMovement.
-/// Do NOT attach this directly to prefabs — attach one of the EnemyAI_X subclasses.
-/// </summary>
 [RequireComponent(typeof(Rigidbody2D))]
 public class BaseEnemy : MonoBehaviour
 {
     [Header("Base Stats  (set on each prefab)")]
-    public float baseMaxHealth = 80f;
+    public float baseMaxHealth = 10f;
     public float baseMoveSpeed = 2.8f;
     public float baseDamage    = 10f;
-    public float baseXPValue   = 5f;
+    public float baseXPValue   = 1f;
+
+    [Header("HP x Level")]
+    [Tooltip("If true, finalHP = baseHP × playerLevel at spawn time (VS mechanic).")]
+    public bool hpScalesWithLevel = false;
 
     [Header("XP Drop")]
     [SerializeField] private GameObject xpOrbPrefab;
@@ -21,77 +21,60 @@ public class BaseEnemy : MonoBehaviour
     public Color  damageFlashColor = Color.red;
     public float  damageFlashTime  = 0.08f;
 
-    // ── Set by the pool on every spawn ───────────────────────────────────────
     [HideInInspector] public float maxHealth;
     [HideInInspector] public float moveSpeed;
     [HideInInspector] public float damage;
     [HideInInspector] public float xpValue;
 
-    // ── Internals ────────────────────────────────────────────────────────────
     protected float       currentHealth;
     protected Transform   player;
     protected Rigidbody2D rb;
 
-    private Color originalColor;   // set once in Awake, never overwritten
+    private Color originalColor;
     private float flashTimer;
     private bool  isFlashing;
 
     private float contactDamageTimer;
     private const float CONTACT_INTERVAL = 0.5f;
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Awake — runs ONCE when the prefab instance is first created by the pool
-    //  Store originalColor here so it never gets corrupted by a flash state
-    // ─────────────────────────────────────────────────────────────────────────
     protected virtual void Awake()
     {
         rb = GetComponent<Rigidbody2D>();
         if (spriteRenderer == null)
             spriteRenderer = GetComponent<SpriteRenderer>();
-
-        // Store the true prefab color here — this only runs once per instance
         if (spriteRenderer != null)
             originalColor = spriteRenderer.color;
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Called by EnemyPool every time this object is pulled from the pool
-    // ─────────────────────────────────────────────────────────────────────────
-    public virtual void OnSpawn(float hpMult, float speedMult, float damageMult)
+    public virtual void OnSpawn(int playerLevel, float speedMult = 1f, float damageMult = 1f)
     {
-        maxHealth  = baseMaxHealth * hpMult;
+        float hpLevel = hpScalesWithLevel ? Mathf.Max(1, playerLevel) : 1f;
+        maxHealth  = baseMaxHealth * hpLevel;
         moveSpeed  = baseMoveSpeed * speedMult;
         damage     = baseDamage    * damageMult;
-        xpValue    = baseXPValue   * Mathf.Sqrt(hpMult);
+        xpValue    = baseXPValue;
 
         currentHealth      = maxHealth;
         contactDamageTimer = 0f;
         flashTimer         = 0f;
         isFlashing         = false;
 
-        // Always restore to the true original color on every spawn
         if (spriteRenderer != null)
             spriteRenderer.color = originalColor;
 
         player = EnemySpawner.Instance != null
-        ? EnemySpawner.Instance.PlayerTransform
-        : GameObject.FindGameObjectWithTag("Player")?.transform;
+            ? EnemySpawner.Instance.PlayerTransform
+            : GameObject.FindGameObjectWithTag("Player")?.transform;
 
         rb.simulated = true;
-
-        Collider2D[] colliders = GetComponents<Collider2D>();
-        foreach (Collider2D col in colliders)
-            col.enabled = true;
+        Collider2D[] cols = GetComponents<Collider2D>();
+        foreach (var c in cols) c.enabled = true;
 
         OnSpawnExtra();
     }
 
-    /// <summary>Override in subclass for per-type spawn init.</summary>
     protected virtual void OnSpawnExtra() { }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Unity lifecycle
-    // ─────────────────────────────────────────────────────────────────────────
     protected virtual void Update()
     {
         if (player == null) return;
@@ -100,36 +83,11 @@ public class BaseEnemy : MonoBehaviour
         UpdateAI();
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  AI hook — override in subclasses
-    // ─────────────────────────────────────────────────────────────────────────
     protected virtual void UpdateAI()
     {
-        Separate();
         MoveTowardsPlayer();
     }
 
-    private void Separate()
-    {
-        Collider2D[] neighbours = Physics2D.OverlapCircleAll(
-            rb.position, 0.5f, LayerMask.GetMask("Enemy"));
-        
-        foreach (Collider2D neighbour in neighbours)
-        {
-            if (neighbour.gameObject == gameObject) continue;
-            
-            Vector2 pushDir = rb.position - (Vector2)neighbour.transform.position;
-            float distance = pushDir.magnitude;
-            
-            if (distance < 0.01f) pushDir = Random.insideUnitCircle;
-            
-            rb.position += pushDir.normalized * 0.02f;
-        }
-    }
-
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Shared movement helpers for subclasses
-    // ─────────────────────────────────────────────────────────────────────────
     protected void MoveTowardsPlayer()
     {
         if (player == null) return;
@@ -149,24 +107,36 @@ public class BaseEnemy : MonoBehaviour
         return Vector2.Distance(rb.position, player.position);
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Health / damage
-    // ─────────────────────────────────────────────────────────────────────────
+    protected virtual void Separate()
+    {
+        Collider2D[] neighbours = Physics2D.OverlapCircleAll(
+            rb.position, 0.5f, LayerMask.GetMask("Enemy"));
+        foreach (Collider2D n in neighbours)
+        {
+            if (n.gameObject == gameObject) continue;
+            Vector2 push = rb.position - (Vector2)n.transform.position;
+            if (push.magnitude < 0.01f) push = Random.insideUnitCircle;
+            rb.position += push.normalized * 0.02f;
+        }
+    }
+
     public void TakeDamage(float amount)
     {
         if (!gameObject.activeSelf) return;
+
+        rb.simulated = false;
+        rb.linearVelocity = Vector2.zero;
+        Collider2D[] cols = GetComponents<Collider2D>();
+        foreach (var c in cols) c.enabled = false;
+
         currentHealth -= amount;
         TriggerFlash();
-        if (currentHealth <= 0f)
+        if (currentHealth <= 0f) Die();
+        else
         {
-            rb.simulated = false;
-            rb.linearVelocity = Vector2.zero;
-
-            Collider2D[] colliders = GetComponents<Collider2D>();
-            foreach (Collider2D col in colliders)
-                col.enabled = false;
-
-            Die();
+            // Re-enable if not dead
+            rb.simulated = true;
+            foreach (var c in cols) c.enabled = true;
         }
     }
 
@@ -188,30 +158,19 @@ public class BaseEnemy : MonoBehaviour
     {
         rb.linearVelocity = Vector2.zero;
         rb.simulated = false;
-
-        Collider2D[] colliders = GetComponents<Collider2D>();
-        foreach (Collider2D col in colliders)
-            col.enabled = false;
-
+        Collider2D[] cols = GetComponents<Collider2D>();
+        foreach (var c in cols) c.enabled = false;
         EnemyPool.Instance?.Return(this);
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Contact damage to player
-    // ─────────────────────────────────────────────────────────────────────────
     protected virtual void OnTriggerStay2D(Collider2D other)
     {
         if (!other.CompareTag("Player")) return;
         if (contactDamageTimer < CONTACT_INTERVAL) return;
         contactDamageTimer = 0f;
-
-        
         PlayerHealth.Instance?.TakeDamage(damage);
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Damage flash
-    // ─────────────────────────────────────────────────────────────────────────
     private void TriggerFlash()
     {
         if (spriteRenderer == null) return;

--- a/Assets/Scripts/BoomerangAbility.cs
+++ b/Assets/Scripts/BoomerangAbility.cs
@@ -2,38 +2,35 @@ using UnityEngine;
 
 public class BoomerangAbility : MonoBehaviour
 {
-    private int boomerangCount = 1;
-    private float damage = 20f;
-    private float cooldown = 3f;
-    private float timer = 0f;
-    private GameObject projectilePrefab;
+    private int   boomerangCount   = 1;
+    private float damageMultiplier = 1.5f; 
+    private float cooldown         = 3f;
+    private float timer            = 0f;
 
     void Start()
     {
-        projectilePrefab = GetComponent<PlayerShooter>().projectilePrefab;
     }
 
     void Update()
     {
         timer += Time.deltaTime;
-        if (timer >= cooldown)
-        {
-            timer = 0f;
-            FireBoomerangs();
-        }
+        if (timer >= cooldown) { timer = 0f; FireBoomerangs(); }
     }
 
     public void LevelUp(int level)
     {
-        boomerangCount = level;
-        damage = 20f + (level - 1) * 15f;
-        cooldown = Mathf.Max(1f, 3f - (level - 1) * 0.2f);
+        boomerangCount   = level;                          // 1, 2, 3, 4...
+        damageMultiplier = 1.5f + (level - 1) * 0.3f;    // 1.5, 1.8, 2.1, 2.4...
+        cooldown         = Mathf.Max(1f, 3f - (level - 1) * 0.25f);
     }
 
     void FireBoomerangs()
     {
-        GameObject nearest = GetComponent<PlayerShooter>().FindNearestEnemy();
+        PlayerShooter shooter = GetComponent<PlayerShooter>();
+        GameObject nearest = shooter != null ? shooter.FindNearestEnemy() : null;
         if (nearest == null) return;
+
+        float damage = PlayerStats.Instance.damage * damageMultiplier;
 
         for (int i = 0; i < boomerangCount; i++)
         {
@@ -42,12 +39,12 @@ public class BoomerangAbility : MonoBehaviour
             dir = RotateVector(dir.normalized, angleOffset);
 
             GameObject boomerang = new GameObject("Boomerang");
-            boomerang.transform.position = transform.position;
-            boomerang.transform.localScale = new Vector3(0.4f, 0.4f, 1f);
+            boomerang.transform.position   = transform.position;
+            boomerang.transform.localScale  = new Vector3(0.4f, 0.4f, 1f);
 
             SpriteRenderer sr = boomerang.AddComponent<SpriteRenderer>();
-            sr.sprite = SpriteHelper.CreateCircle();
-            sr.color = new Color(1f, 0.8f, 0.2f);
+            sr.sprite       = SpriteHelper.CreateCircle();
+            sr.color        = new Color(1f, 0.8f, 0.2f);
             sr.sortingOrder = 2;
 
             Rigidbody2D rb = boomerang.AddComponent<Rigidbody2D>();
@@ -55,7 +52,7 @@ public class BoomerangAbility : MonoBehaviour
 
             CircleCollider2D col = boomerang.AddComponent<CircleCollider2D>();
             col.isTrigger = true;
-            col.radius = 0.3f;
+            col.radius    = 0.3f;
 
             BoomerangProjectile bp = boomerang.AddComponent<BoomerangProjectile>();
             bp.Initialize(transform, dir, damage, PlayerStats.Instance.projectileSpeed);

--- a/Assets/Scripts/BouncingShotAbility.cs
+++ b/Assets/Scripts/BouncingShotAbility.cs
@@ -2,33 +2,26 @@ using UnityEngine;
 
 public class BouncingShotAbility : MonoBehaviour
 {
-    private int bounceCount = 2;
-    private float damage = 15f;
+    private int   bounceCount      = 2;
+    private float damageMultiplier = 1.2f; 
 
     public void LevelUp(int level)
     {
-        bounceCount = 1 + level;
-        damage = 15f + (level - 1) * 10f;
+        bounceCount      = 1 + level;                  // 2, 3, 4, 5...
+        damageMultiplier = 1.2f + (level - 1) * 0.15f; // 1.2, 1.35, 1.5, 1.65...
     }
 
-    public void FireBouncingShot(Vector2 direction)
+    public int GetBounceCount() => bounceCount;
+
+    public void FireBouncingShot(Vector2 direction, GameObject projectilePrefab, PlayerShooter shooter)
     {
-        GameObject bullet = new GameObject("BouncingBullet");
-        bullet.transform.position = transform.position;
-        bullet.transform.localScale = new Vector3(0.3f, 0.3f, 1f);
+        float damage = PlayerStats.Instance.damage * damageMultiplier;
 
-        SpriteRenderer sr = bullet.AddComponent<SpriteRenderer>();
-        sr.sprite = SpriteHelper.CreateCircle();
-        sr.color = new Color(0.3f, 0.8f, 1f);
-        sr.sortingOrder = 2;
+        GameObject bullet = Instantiate(projectilePrefab, transform.position, Quaternion.identity);
+        shooter.ApplyProjectileVisual(bullet, direction);
 
-        Rigidbody2D rb = bullet.AddComponent<Rigidbody2D>();
-        rb.gravityScale = 0f;
-        rb.linearVelocity = direction * PlayerStats.Instance.projectileSpeed;
-
-        CircleCollider2D col = bullet.AddComponent<CircleCollider2D>();
-        col.isTrigger = true;
-        col.radius = 0.15f;
+        Rigidbody2D rb = bullet.GetComponent<Rigidbody2D>();
+        if (rb != null) rb.linearVelocity = direction * PlayerStats.Instance.projectileSpeed;
 
         BouncingBullet bb = bullet.AddComponent<BouncingBullet>();
         bb.Initialize(damage, bounceCount);

--- a/Assets/Scripts/BouncingShotAbility.cs
+++ b/Assets/Scripts/BouncingShotAbility.cs
@@ -23,6 +23,9 @@ public class BouncingShotAbility : MonoBehaviour
         Rigidbody2D rb = bullet.GetComponent<Rigidbody2D>();
         if (rb != null) rb.linearVelocity = direction * PlayerStats.Instance.projectileSpeed;
 
+        Projectile proj = bullet.GetComponent<Projectile>();
+        if (proj != null) proj.enabled = false;
+
         BouncingBullet bb = bullet.AddComponent<BouncingBullet>();
         bb.Initialize(damage, bounceCount);
     }

--- a/Assets/Scripts/EnemyAI_Charger.cs
+++ b/Assets/Scripts/EnemyAI_Charger.cs
@@ -16,6 +16,13 @@ public class EnemyAI_Charger : BaseEnemy
     private Vector2 dashDir;
     private Color   baseColor;
 
+    public override void OnSpawn(int playerLevel, float speedMult = 1f, float damageMult = 1f)
+    {
+        int layer = LayerMask.NameToLayer("Enemy");
+        Physics2D.IgnoreLayerCollision(layer, layer, false);
+        base.OnSpawn(playerLevel, speedMult, damageMult);
+    }
+
     protected override void OnSpawnExtra()
     {
         state      = State.Approach;
@@ -73,8 +80,6 @@ public class EnemyAI_Charger : BaseEnemy
         state      = State.Dash;
         stateTimer = 0f;
         if (spriteRenderer != null) spriteRenderer.color = baseColor;
-
-        // Ignore enemy-enemy collisions during the dash so nothing blocks it
         int layer = LayerMask.NameToLayer("Enemy");
         Physics2D.IgnoreLayerCollision(layer, layer, true);
     }
@@ -83,17 +88,7 @@ public class EnemyAI_Charger : BaseEnemy
     {
         state      = State.Cooldown;
         stateTimer = 0f;
-
-        // Re-enable enemy-enemy collisions after the dash
         int layer = LayerMask.NameToLayer("Enemy");
         Physics2D.IgnoreLayerCollision(layer, layer, false);
-    }
-
-    // Make sure collisions are always restored if this enemy is recycled mid-dash
-    public override void OnSpawn(float hpMult, float speedMult, float damageMult)
-    {
-        int layer = LayerMask.NameToLayer("Enemy");
-        Physics2D.IgnoreLayerCollision(layer, layer, false);
-        base.OnSpawn(hpMult, speedMult, damageMult);
     }
 }

--- a/Assets/Scripts/EnemyAI_Elite.cs
+++ b/Assets/Scripts/EnemyAI_Elite.cs
@@ -10,13 +10,12 @@ public class EnemyAI_Elite : BaseEnemy
     {
         if (spriteRenderer != null)
             spriteRenderer.color = eliteColor;
-
         transform.localScale = Vector3.one * 1.6f;
     }
 
     protected override void Die()
     {
-        transform.localScale = Vector3.one;   // reset scale before returning to pool
-        base.Die();                           // base.Die() handles XP drop + pool return
+        transform.localScale = Vector3.one;
+        base.Die();
     }
 }

--- a/Assets/Scripts/EnemyAI_Projector.cs
+++ b/Assets/Scripts/EnemyAI_Projector.cs
@@ -1,20 +1,19 @@
 using UnityEngine;
 
-// Keeps its distance and fires projectiles at the player
 public class EnemyAI_Projector : BaseEnemy
 {
     [Header("Projector Settings")]
     public GameObject projectilePrefab;
     public float preferredRange   = 7f;
-    public float fireRate         = 1.5f;
-    public float projectileSpeed  = 5f;
-    public float projectileDamage = 8f;
+    public float fireRate         = 0.25f; 
+    public float projectileSpeed  = 3f;     
+    public float projectileDamage = 20f;    
 
     private float shootTimer;
 
     protected override void OnSpawnExtra()
     {
-        shootTimer = 1f / fireRate;   // start ready to fire immediately
+        shootTimer = -Random.Range(1f, 6f);
     }
 
     protected override void UpdateAI()
@@ -22,16 +21,11 @@ public class EnemyAI_Projector : BaseEnemy
         float dist = DistanceToPlayer();
 
         if (dist < preferredRange - 1f)
-        {
-            rb.linearVelocity = -DirectionToPlayer() * moveSpeed;         // back away
-        }
+            rb.linearVelocity = -DirectionToPlayer() * moveSpeed;
         else if (dist > preferredRange + 1f)
-        {
-            rb.linearVelocity = DirectionToPlayer() * moveSpeed * 0.6f;   // close in slowly
-        }
+            rb.linearVelocity = DirectionToPlayer() * moveSpeed * 0.6f;
         else
         {
-            // In sweet spot — strafe sideways
             Vector2 perp = new Vector2(-DirectionToPlayer().y, DirectionToPlayer().x);
             rb.linearVelocity = perp * moveSpeed * 0.4f;
         }

--- a/Assets/Scripts/EnemyPool.cs
+++ b/Assets/Scripts/EnemyPool.cs
@@ -1,11 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
 
-/// <summary>
-/// Pre-allocates all enemy instances at startup.
-/// The spawner calls Get() / Return() instead of Instantiate / Destroy.
-/// Attach this to an empty GameObject called "EnemyPool" in your scene.
-/// </summary>
 public class EnemyPool : MonoBehaviour
 {
     public static EnemyPool Instance { get; private set; }
@@ -28,15 +23,14 @@ public class EnemyPool : MonoBehaviour
     {
         if (Instance != null && Instance != this) { Destroy(gameObject); return; }
         Instance = this;
-
         foreach (var entry in poolEntries)
             PreWarm(entry.prefab, entry.preWarmCount);
     }
 
-    public BaseEnemy Get(GameObject prefab, Vector2 position, float hpMult, float speedMult, float damageMult)
+    public BaseEnemy Get(GameObject prefab, Vector2 position, int playerLevel,
+                         float speedMult = 1f, float damageMult = 1f)
     {
         string key = prefab.name;
-
         if (!available.ContainsKey(key) || available[key].Count == 0)
             Grow(prefab, 10);
 
@@ -44,15 +38,15 @@ public class EnemyPool : MonoBehaviour
         enemy.transform.position = position;
         enemy.gameObject.SetActive(true);
         activeKey[enemy] = key;
-        enemy.OnSpawn(hpMult, speedMult, damageMult);
+        enemy.OnSpawn(playerLevel, speedMult, damageMult);
         return enemy;
     }
 
+    /// <summary>Return an enemy to the pool.</summary>
     public void Return(BaseEnemy enemy)
     {
         if (enemy == null) return;
         enemy.gameObject.SetActive(false);
-
         if (activeKey.TryGetValue(enemy, out string key))
         {
             activeKey.Remove(enemy);
@@ -74,16 +68,14 @@ public class EnemyPool : MonoBehaviour
         for (int i = 0; i < count; i++)
         {
             GameObject go = Instantiate(prefab, Vector3.zero, Quaternion.identity, transform);
-            go.name = key;   
-
+            go.name = key;
             BaseEnemy enemy = go.GetComponent<BaseEnemy>();
             if (enemy == null)
             {
-                Debug.LogError($"[EnemyPool] '{key}' has no BaseEnemy component! Remove it from the pool.");
+                Debug.LogError($"[EnemyPool] '{key}' has no BaseEnemy component!");
                 Destroy(go);
                 continue;
             }
-
             go.SetActive(false);
             available[key].Push(enemy);
         }

--- a/Assets/Scripts/EnemyProjectile.cs
+++ b/Assets/Scripts/EnemyProjectile.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
 
-/// <summary>
-/// Attach to the enemy projectile prefab.
-/// Requires a Rigidbody2D and a Collider2D set to Is Trigger.
-/// </summary>
 [RequireComponent(typeof(Rigidbody2D))]
 public class EnemyProjectile : MonoBehaviour
 {
@@ -27,10 +23,7 @@ public class EnemyProjectile : MonoBehaviour
     void OnTriggerEnter2D(Collider2D other)
     {
         if (!other.CompareTag("Player")) return;
-
-        // ── Hook your player health system here ──
-        // PlayerHealth.Instance?.TakeDamage(damage);
-
+        PlayerHealth.Instance?.TakeDamage(damage);
         Destroy(gameObject);
     }
 }

--- a/Assets/Scripts/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySpawner.cs
@@ -2,22 +2,18 @@ using UnityEngine;
 using System.Collections.Generic;
 
 /// <summary>
-/// The invisible director of the entire experience.
+/// Core loop (runs every wave.spawnInterval seconds):
+///   1. If total alive >= hardCap → skip
+///   2. For each enemy type in the current wave:
+///      - If alive count < minimum → spawn until quota filled
+///      - If already at or over minimum → spawn exactly 1
 ///
-/// Reads the WaveTable ScriptableObject to know:
-///   — which enemies to spawn each minute
-///   — how fast to pulse spawns
-///   — when to fire special events (SwarmRush, ArenaRing, Stalker, WallSpawn)
+/// HP scaling: finalHP = baseHP × playerLevel  (if hpScalesWithLevel is set on the prefab)
+/// Speed/Damage: flat multipliers (default 1.0)
 ///
-/// Uses EnemyPool instead of Instantiate/Destroy.
-/// Teleports distant enemies back to the spawn ring to recycle them.
-/// Watches the player's kill rate and fires a Wall Spawn if they kill too fast.
-///
-/// Scene requirements:
-///   • An EnemyPool GameObject (with all prefabs registered)
-///   • This WaveTable ScriptableObject assigned below
-///   • Player GameObject tagged "Player"
-///   • Camera.main (orthographic)
+/// Also handles:
+///   - Timed map events (SwarmRush, WallSpawn, ArenaRing)
+///   - Teleport recycling of distant enemies
 /// </summary>
 public class EnemySpawner : MonoBehaviour
 {
@@ -32,33 +28,23 @@ public class EnemySpawner : MonoBehaviour
     [Tooltip("Enemies beyond despawnDistance + this get teleported back")]
     public float extraDespawnBuffer = 2f;
 
-    // ── Exposed to BaseEnemy so it can find the player quickly ──────────────
     public Transform PlayerTransform { get; private set; }
 
-    // ── Private runtime ──────────────────────────────────────────────────────
     private Camera cam;
     private float  gameTime      = 0f;
     private float  spawnTimer    = 0f;
     private float  teleportTimer = 0f;
 
-    // Kill-rate tracking
-    private int   recentKills    = 0;
-    private float killRateTimer  = 0f;
-    private float wallCooldown   = 0f;
-    private const float KILL_WINDOW = 3f;
+    private Dictionary<string, int> alivePerType = new Dictionary<string, int>();
 
-    // Special events
-    private bool         eventActive = false;
-    private float        eventTimer  = 0f;
-    private SpecialEvent activeEvent;
-    private int          swarmEdge   = 0;
-
-    // Live enemy list for teleport scanning
     private List<BaseEnemy> liveEnemies = new List<BaseEnemy>();
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Unity
-    // ─────────────────────────────────────────────────────────────────────────
+    private bool      swarmActive  = false;
+    private float     swarmTimer   = 0f;
+    private float     swarmDuration = 0f;
+    private GameObject swarmPrefab  = null;
+    private int       swarmEdge     = 0;
+
 
     void Awake()
     {
@@ -71,10 +57,9 @@ public class EnemySpawner : MonoBehaviour
         cam = Camera.main;
         GameObject p = GameObject.FindGameObjectWithTag("Player");
         if (p != null) PlayerTransform = p.transform;
-        else Debug.LogError("[EnemySpawner] No GameObject tagged 'Player' found!");
+        else Debug.LogError("[EnemySpawner] No Player tagged 'Player' found!");
 
-        if (waveTable == null)
-            Debug.LogError("[EnemySpawner] WaveTable not assigned!");
+        if (waveTable == null) Debug.LogError("[EnemySpawner] WaveTable not assigned!");
     }
 
     void Update()
@@ -84,33 +69,27 @@ public class EnemySpawner : MonoBehaviour
         gameTime      += Time.deltaTime;
         spawnTimer    += Time.deltaTime;
         teleportTimer += Time.deltaTime;
-        killRateTimer += Time.deltaTime;
-        if (wallCooldown > 0f) wallCooldown -= Time.deltaTime;
 
-        // ── Kill-rate check ──────────────────────────────────────────────────
-        if (killRateTimer >= KILL_WINDOW)
-        {
-            float rate    = recentKills / KILL_WINDOW;
-            recentKills   = 0;
-            killRateTimer = 0f;
+        TickMapEvents();
 
-            if (rate >= waveTable.wallTriggerKillRate && wallCooldown <= 0f)
-                TriggerWallSpawn();
-        }
-
-        // ── Special events ───────────────────────────────────────────────────
-        TickSpecialEvents();
-
-        // ── Main spawn pulse  (paused during a SwarmRush) ───────────────────
-        float interval = waveTable.GetSpawnInterval(gameTime);
-        if (spawnTimer >= interval)
+        WaveDefinition wave = waveTable.GetWave(gameTime);
+        if (wave != null && spawnTimer >= wave.spawnInterval)
         {
             spawnTimer = 0f;
-            if (!IsEventActive(SpecialEventType.SwarmRush))
-                SpawnPulse();
+            if (!swarmActive) // pause regular spawns during a swarm rush
+                RunQuotaFill(wave);
         }
 
-        // ── Teleport distant enemies back to the spawn ring ──────────────────
+        if (swarmActive)
+        {
+            swarmTimer += Time.deltaTime;
+            if (Mathf.FloorToInt(swarmTimer / 0.25f) > Mathf.FloorToInt((swarmTimer - Time.deltaTime) / 0.25f))
+                SpawnEnemy(swarmPrefab, GetEdgePosition(swarmEdge));
+
+            if (swarmTimer >= swarmDuration)
+                swarmActive = false;
+        }
+
         if (teleportTimer >= waveTable.teleportScanInterval)
         {
             teleportTimer = 0f;
@@ -118,184 +97,94 @@ public class EnemySpawner : MonoBehaviour
         }
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Main spawn pulse
-    // ─────────────────────────────────────────────────────────────────────────
 
-    void SpawnPulse()
+    void RunQuotaFill(WaveDefinition wave)
     {
-        int cap    = waveTable.GetEnemyCap(gameTime);
-        int active = EnemyPool.Instance != null ? EnemyPool.Instance.ActiveCount : 0;
-        if (active >= cap) return;
+        int totalAlive = EnemyPool.Instance != null ? EnemyPool.Instance.ActiveCount : 0;
+        if (totalAlive >= waveTable.hardCap) return;
 
-        MinuteWindow window = waveTable.GetActiveWindow(gameTime);
-        if (window == null || window.rules.Count == 0) return;
-
-        SpawnRule rule = PickRule(window.rules);
-        if (rule == null || rule.enemyPrefab == null) return;
-
-        Vector2 origin = GetSpawnRingPosition();
-
-        if (rule.spawnInClusters)
+        foreach (var entry in wave.enemies)
         {
-            int count = Mathf.Min(
-                Random.Range(rule.minClusterSize, rule.maxClusterSize + 1),
-                cap - active   // never exceed cap in one pulse
-            );
-            for (int i = 0; i < count; i++)
-                SpawnEnemy(rule.enemyPrefab, origin + Random.insideUnitCircle * rule.clusterSpread);
-        }
-        else
-        {
-            SpawnEnemy(rule.enemyPrefab, origin);
+            if (entry.prefab == null) continue;
+
+            string key   = entry.prefab.name;
+            int    alive = alivePerType.ContainsKey(key) ? alivePerType[key] : 0;
+
+            if (alive < entry.minimumAlive)
+            {
+                // Fill to quota
+                int needed = entry.minimumAlive - alive;
+                for (int i = 0; i < needed; i++)
+                {
+                    if (EnemyPool.Instance.ActiveCount >= waveTable.hardCap) break;
+                    SpawnEnemy(entry.prefab, GetSpawnRingPosition());
+                }
+            }
+            else
+            {
+                if (EnemyPool.Instance.ActiveCount < waveTable.hardCap)
+                    SpawnEnemy(entry.prefab, GetSpawnRingPosition());
+            }
         }
     }
+
 
     void SpawnEnemy(GameObject prefab, Vector2 position)
     {
-        if (EnemyPool.Instance == null) return;
+        if (EnemyPool.Instance == null || prefab == null) return;
 
-        float hpMult     = waveTable.GetHPMultiplier(gameTime);
-        float speedMult  = waveTable.GetSpeedMultiplier(gameTime);
-        float damageMult = waveTable.GetDamageMultiplier(gameTime);
+        int playerLevel = GameManager.Instance != null
+            ? GameManager.Instance.GetCurrentLevel()
+            : 1;
 
-        BaseEnemy enemy = EnemyPool.Instance.Get(prefab, position, hpMult, speedMult, damageMult);
+        BaseEnemy enemy = EnemyPool.Instance.Get(prefab, position, playerLevel);
         if (enemy != null)
+        {
             liveEnemies.Add(enemy);
+            string key = prefab.name;
+            if (!alivePerType.ContainsKey(key)) alivePerType[key] = 0;
+            alivePerType[key]++;
+        }
     }
-
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Called by BaseEnemy.Die()
-    // ─────────────────────────────────────────────────────────────────────────
 
     public void OnEnemyDied(BaseEnemy enemy)
     {
-        recentKills++;
         liveEnemies.Remove(enemy);
+        string key = enemy.gameObject.name;
+        if (alivePerType.ContainsKey(key))
+            alivePerType[key] = Mathf.Max(0, alivePerType[key] - 1);
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Teleport recycling
-    // ─────────────────────────────────────────────────────────────────────────
 
-    void RecycleDistantEnemies()
+    void TickMapEvents()
     {
-        float maxDist = waveTable.despawnDistance + extraDespawnBuffer;
-
-        for (int i = liveEnemies.Count - 1; i >= 0; i--)
+        foreach (var ev in waveTable.mapEvents)
         {
-            BaseEnemy e = liveEnemies[i];
-            if (e == null || !e.gameObject.activeSelf)
-            {
-                liveEnemies.RemoveAt(i);
-                continue;
-            }
-
-            if (Vector2.Distance(e.transform.position, PlayerTransform.position) > maxDist)
-                e.transform.position = GetSpawnRingPosition();
+            if (ev.triggered || gameTime < ev.triggerTime) continue;
+            ev.triggered = true;
+            Debug.Log($"[EnemySpawner] Map event: {ev.label} ({ev.eventType})");
+            TriggerMapEvent(ev);
         }
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Wall Spawn  (DPS counter-measure)
-    // ─────────────────────────────────────────────────────────────────────────
-
-    void TriggerWallSpawn()
-    {
-        wallCooldown = waveTable.wallSpawnCooldown;
-        Debug.Log("[EnemySpawner] Wall spawn triggered!");
-
-        MinuteWindow window = waveTable.GetActiveWindow(gameTime);
-        if (window == null || window.rules.Count == 0) return;
-
-        // Use the heaviest-weight rule as the wall material (usually the tankiest)
-        SpawnRule wallRule = window.rules[0];
-        foreach (var r in window.rules)
-            if (r.spawnWeight > wallRule.spawnWeight) wallRule = r;
-
-        if (wallRule.enemyPrefab == null) return;
-
-        int   count  = 16;
-        float radius = CamHH() + spawnRingPadding + 1f;
-
-        for (int i = 0; i < count; i++)
-        {
-            float   angle = (360f / count) * i * Mathf.Deg2Rad;
-            Vector2 pos   = (Vector2)PlayerTransform.position
-                            + new Vector2(Mathf.Cos(angle), Mathf.Sin(angle)) * radius;
-            SpawnEnemy(wallRule.enemyPrefab, pos);
-        }
-    }
-
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Special events
-    // ─────────────────────────────────────────────────────────────────────────
-
-    void TickSpecialEvents()
-    {
-        foreach (var ev in waveTable.specialEvents)
-        {
-            if (!ev.triggered && gameTime >= ev.triggerTime)
-            {
-                ev.triggered = true;
-                activeEvent  = ev;
-                eventActive  = true;
-                eventTimer   = 0f;
-                swarmEdge    = Random.Range(0, 4);
-                Debug.Log($"[EnemySpawner] Event started: {ev.eventType}");
-                OnEventStart(ev);
-            }
-        }
-
-        if (!eventActive) return;
-
-        eventTimer += Time.deltaTime;
-        OnEventTick(activeEvent, eventTimer);
-
-        if (eventTimer >= activeEvent.duration)
-        {
-            Debug.Log($"[EnemySpawner] Event ended: {activeEvent.eventType}");
-            eventActive = false;
-            activeEvent = null;
-        }
-    }
-
-    void OnEventStart(SpecialEvent ev)
+    void TriggerMapEvent(MapEvent ev)
     {
         switch (ev.eventType)
         {
-            case SpecialEventType.ArenaRing:
-            case SpecialEventType.WallSpawn:
+            case MapEventType.SwarmRush:
+                swarmActive   = true;
+                swarmTimer    = 0f;
+                swarmDuration = ev.duration;
+                swarmPrefab   = ev.enemyPrefab;
+                swarmEdge     = Random.Range(0, 4);
+                break;
+
+            case MapEventType.WallSpawn:
+            case MapEventType.ArenaRing:
                 SpawnRing(ev.enemyPrefab, ev.enemyCount, ev.ringRadius);
                 break;
-
-            case SpecialEventType.Stalker:
-                if (ev.enemyPrefab != null)
-                    SpawnEnemy(ev.enemyPrefab, GetSpawnRingPosition());
-                break;
-
-            // SwarmRush spawns gradually in OnEventTick
         }
     }
-
-    void OnEventTick(SpecialEvent ev, float elapsed)
-    {
-        if (ev.eventType != SpecialEventType.SwarmRush) return;
-
-        // Every 0.25 s, fire a batch of swarmers from one screen edge
-        bool newTick = Mathf.FloorToInt(elapsed / 0.25f)
-                     > Mathf.FloorToInt((elapsed - Time.deltaTime) / 0.25f);
-        if (!newTick || ev.enemyPrefab == null) return;
-
-        int totalTicks = Mathf.Max(1, Mathf.RoundToInt(ev.duration / 0.25f));
-        int batch      = Mathf.Max(1, ev.enemyCount / totalTicks);
-
-        for (int i = 0; i < batch; i++)
-            SpawnEnemy(ev.enemyPrefab, GetEdgePosition(swarmEdge));
-    }
-
-    bool IsEventActive(SpecialEventType type)
-        => eventActive && activeEvent != null && activeEvent.eventType == type;
 
     void SpawnRing(GameObject prefab, int count, float radius)
     {
@@ -309,28 +198,23 @@ public class EnemySpawner : MonoBehaviour
         }
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Weighted rule picker
-    // ─────────────────────────────────────────────────────────────────────────
 
-    SpawnRule PickRule(List<SpawnRule> rules)
+    void RecycleDistantEnemies()
     {
-        float total = 0f;
-        foreach (var r in rules) total += r.spawnWeight;
-
-        float roll       = Random.Range(0f, total);
-        float cumulative = 0f;
-        foreach (var r in rules)
+        float maxDist = waveTable.despawnDistance + extraDespawnBuffer;
+        for (int i = liveEnemies.Count - 1; i >= 0; i--)
         {
-            cumulative += r.spawnWeight;
-            if (roll <= cumulative) return r;
+            BaseEnemy e = liveEnemies[i];
+            if (e == null || !e.gameObject.activeSelf)
+            {
+                liveEnemies.RemoveAt(i);
+                continue;
+            }
+            if (Vector2.Distance(e.transform.position, PlayerTransform.position) > maxDist)
+                e.transform.position = GetSpawnRingPosition();
         }
-        return rules[rules.Count - 1];
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    //  Position helpers
-    // ─────────────────────────────────────────────────────────────────────────
 
     Vector2 GetSpawnRingPosition() => GetEdgePosition(Random.Range(0, 4));
 
@@ -339,7 +223,6 @@ public class EnemySpawner : MonoBehaviour
         float hw = CamHW() + spawnRingPadding;
         float hh = CamHH() + spawnRingPadding;
         Vector2 p = PlayerTransform.position;
-
         return edge switch
         {
             0 => new Vector2(p.x + Random.Range(-hw, hw), p.y + hh),

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -6,63 +6,71 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager Instance;
 
-    [Header("XP Settings")]
-    [SerializeField] private float baseXPToLevel = 100f;
-    [SerializeField] private float xpScalingPerLevel = 50f;
+    private int   currentLevel    = 1;
+    private float currentXP       = 0f;
+    private float xpToNextLevel   = 5f;   
 
-    private int   currentLevel   = 1;
-    private float currentXP      = 0f;
-    private float xpToNextLevel;
+    private float growthMultiplier = 1f;
+
 
     void Awake()
     {
         Instance = this;
-        xpToNextLevel = baseXPToLevel;
+        xpToNextLevel = GetXPRequired(currentLevel);
     }
 
-    // TESTIMISEKS, VAJUTADES L, NAITAB LEVEL UP EKRAANI UI'D
-    void Update()
+    //  XP — three-phase VS curve
+    //
+    //  Phase 1  L1–20:  starts at 5, +10 per level    (5, 15, 25 … 195)
+    //  Phase 2  L21–40: starts at 205, +13 per level  (208, 221 … 455)
+    //  Phase 3  L41+:   starts at 471, +16 per level  (471, 487 …)
+
+    public static float GetXPRequired(int level)
     {
-        if (Keyboard.current.lKey.wasPressedThisFrame)
-            TriggerLevelUp();
+        if (level <= 20)
+            return 5f + (level - 1) * 10f;
+        else if (level <= 40)
+            return 195f + (level - 20) * 13f;
+        else
+            return 455f + (level - 40) * 16f;
     }
-
-    // ── XP ───────────────────────────────────────────────────────────────────
 
     public void AddXP(float amount)
     {
-        currentXP += amount;
+        currentXP += amount * growthMultiplier;
         XPBarUI.Instance?.UpdateBar(currentXP, xpToNextLevel);
 
         while (currentXP >= xpToNextLevel)
         {
             currentXP     -= xpToNextLevel;
-            xpToNextLevel  = baseXPToLevel + (currentLevel * xpScalingPerLevel);
             TriggerLevelUp();
+            xpToNextLevel  = GetXPRequired(currentLevel);
         }
+
+        XPBarUI.Instance?.UpdateBar(currentXP, xpToNextLevel);
     }
 
-    // ── Level up ─────────────────────────────────────────────────────────────
-
-    // DENISSI XP SUSTEEM CALLIB SELLE KUI MANGIJA SAAB LEVEL UPI
     public void TriggerLevelUp()
     {
         currentLevel++;
-        LevelUpUI.Instance.Show(UpgradeManager.Instance.GetUpgradeChoices());
+        LevelUpUI.Instance?.Show(UpgradeManager.Instance?.GetUpgradeChoices());
     }
 
-    // ── Death / reset ─────────────────────────────────────────────────────────
 
     public void ResetGame()
     {
-        // Reload the current scene — resets everything
         Time.timeScale = 1f;
         SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
     }
 
-    // ── Getters ──────────────────────────────────────────────────────────────
 
     public int   GetCurrentLevel()  => currentLevel;
     public float GetCurrentXP()     => currentXP;
     public float GetXPToNextLevel() => xpToNextLevel;
+    public float GetGrowthMultiplier() => growthMultiplier;
+
+    public void SetGrowthMultiplier(float mult)
+    {
+        growthMultiplier = Mathf.Max(0.1f, mult);
+    }
 }

--- a/Assets/Scripts/LightningChainAbility.cs
+++ b/Assets/Scripts/LightningChainAbility.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 
 public class LightningChainAbility : MonoBehaviour
 {
-    private float damage     = 25f;
-    private int   chainJumps = 2;
-    private float chainRange = 4f;
-    private float cooldown   = 2.5f;
-    private float timer      = 0f;
+    private float damageMultiplier = 2.0f; 
+    private int   chainJumps       = 2;
+    private float chainRange       = 4f;
+    private float cooldown         = 2.5f;
+    private float timer            = 0f;
 
     void Update()
     {
@@ -17,9 +17,10 @@ public class LightningChainAbility : MonoBehaviour
 
     public void LevelUp(int level)
     {
-        damage     = 25f + (level - 1) * 15f;
-        chainJumps = 1 + level;
-        cooldown   = Mathf.Max(0.8f, 2.5f - (level - 1) * 0.2f);
+        damageMultiplier = 2.0f + (level - 1) * 0.5f;    // 2.0, 2.5, 3.0, 3.5...
+        chainJumps       = 2 + level;                      // 2, 3, 4, 5...
+        chainRange       = 4f + (level - 1) * 0.5f;
+        cooldown         = Mathf.Max(0.8f, 2.5f - (level - 1) * 0.25f);
     }
 
     void TriggerLightning()
@@ -36,26 +37,26 @@ public class LightningChainAbility : MonoBehaviour
         }
 
         if (first == null) return;
+
+        float damage = PlayerStats.Instance.damage * damageMultiplier;
         ChainLightning(first, new List<GameObject>(), chainJumps, damage, transform.position);
     }
 
-    void ChainLightning(GameObject target, List<GameObject> alreadyHit, int jumpsLeft, float currentDamage, Vector3 fromPos)
+    void ChainLightning(GameObject target, List<GameObject> alreadyHit, int jumpsLeft,
+                        float currentDamage, Vector3 fromPos)
     {
         if (target == null) return;
-
         alreadyHit.Add(target);
 
         BaseEnemy enemy = target.GetComponent<BaseEnemy>();
         if (enemy != null) enemy.TakeDamage(currentDamage);
 
         SpawnLightningVisual(fromPos, target.transform.position);
-
         if (jumpsLeft <= 0) return;
 
         GameObject[] enemies = GameObject.FindGameObjectsWithTag("Enemy");
         GameObject   next    = null;
         float        minDist = Mathf.Infinity;
-
         foreach (GameObject e in enemies)
         {
             if (alreadyHit.Contains(e)) continue;
@@ -64,7 +65,8 @@ public class LightningChainAbility : MonoBehaviour
         }
 
         if (next != null)
-            ChainLightning(next, alreadyHit, jumpsLeft - 1, currentDamage * 0.7f, target.transform.position);
+            ChainLightning(next, alreadyHit, jumpsLeft - 1, currentDamage * 0.7f,
+                           target.transform.position);
     }
 
     void SpawnLightningVisual(Vector3 fromPos, Vector3 toPos)

--- a/Assets/Scripts/OrbitalAbility.cs
+++ b/Assets/Scripts/OrbitalAbility.cs
@@ -3,19 +3,20 @@ using System.Collections.Generic;
 
 public class OrbitalAbility : MonoBehaviour
 {
-    private int orbCount = 1;
-    private float orbitRadius = 2f;
-    private float orbitSpeed = 180f;
-    private float damage = 15f;
-    private float damageCooldown = 0.5f;
-    private List<GameObject> orbs = new List<GameObject>();
-    private float angle = 0f;
+    private int   orbCount         = 1;
+    private float orbitRadius      = 2f;
+    private float orbitSpeed       = 180f;
+    private float damageMultiplier = 1.0f;
+    private float damageCooldown   = 0.5f;
+    private List<GameObject> orbs  = new List<GameObject>();
+    private float angle            = 0f;
 
     public void LevelUp(int level)
     {
-        orbCount = level;
-        damage = 15f + (level - 1) * 10f;
-        orbitRadius = 2f + (level - 1) * 0.2f;
+        orbCount         = level;                          // 1, 2, 3, 4...
+        damageMultiplier = 1.0f + (level - 1) * 0.25f;   // 1.0, 1.25, 1.5, 1.75...
+        orbitRadius      = 2.0f + (level - 1) * 0.2f;
+        damageCooldown   = Mathf.Max(0.2f, 0.5f - (level - 1) * 0.05f);
         RefreshOrbs();
     }
 
@@ -34,6 +35,10 @@ public class OrbitalAbility : MonoBehaviour
                 Mathf.Sin(rad) * orbitRadius,
                 0f
             );
+
+            OrbDamager damager = orbs[i].GetComponent<OrbDamager>();
+            if (damager != null)
+                damager.damage = PlayerStats.Instance.damage * damageMultiplier;
         }
     }
 
@@ -52,8 +57,8 @@ public class OrbitalAbility : MonoBehaviour
         GameObject orb = new GameObject("Orb");
 
         SpriteRenderer sr = orb.AddComponent<SpriteRenderer>();
-        sr.sprite = SpriteHelper.CreateCircle();
-        sr.color = new Color(1f, 0.6f, 0f, 1f);
+        sr.sprite       = SpriteHelper.CreateCircle();
+        sr.color        = new Color(1f, 0.6f, 0f, 1f);
         sr.sortingOrder = 2;
         orb.transform.localScale = Vector3.one * 0.4f;
 
@@ -61,7 +66,7 @@ public class OrbitalAbility : MonoBehaviour
         col.isTrigger = true;
 
         OrbDamager damager = orb.AddComponent<OrbDamager>();
-        damager.damage = damage;
+        damager.damage         = PlayerStats.Instance.damage * damageMultiplier;
         damager.damageCooldown = damageCooldown;
 
         return orb;

--- a/Assets/Scripts/PiercingArrowAbility.cs
+++ b/Assets/Scripts/PiercingArrowAbility.cs
@@ -2,29 +2,31 @@ using UnityEngine;
 
 public class PiercingArrowAbility : MonoBehaviour
 {
-    private float damage = 30f;
-    private int pierceCount = 3;
+    private float damageMultiplier = 2.5f; 
+    private int   pierceCount      = 3;
 
     public void LevelUp(int level)
     {
-        damage = 30f + (level - 1) * 20f;
-        pierceCount = 2 + level;
+        damageMultiplier = 2.5f + (level - 1) * 0.5f;  // 2.5, 3.0, 3.5, 4.0...
+        pierceCount      = 2 + level;                    // 3, 4, 5, 6...
     }
 
     public void FirePiercingArrow(Vector2 direction)
     {
+        float damage = PlayerStats.Instance.damage * damageMultiplier;
+
         GameObject arrow = new GameObject("PiercingArrow");
-        arrow.transform.position = transform.position;
+        arrow.transform.position   = transform.position;
         arrow.transform.localScale = new Vector3(0.2f, 0.6f, 1f);
 
         SpriteRenderer sr = arrow.AddComponent<SpriteRenderer>();
-        sr.sprite = SpriteHelper.CreateCircle();
-        sr.color = new Color(0.4f, 1f, 0.4f);
+        sr.sprite       = SpriteHelper.CreateCircle();
+        sr.color        = new Color(0.4f, 1f, 0.4f);
         sr.sortingOrder = 2;
 
         Rigidbody2D rb = arrow.AddComponent<Rigidbody2D>();
-        rb.gravityScale = 0f;
-        rb.linearVelocity = direction * PlayerStats.Instance.projectileSpeed * 1.5f;
+        rb.gravityScale    = 0f;
+        rb.linearVelocity  = direction * PlayerStats.Instance.projectileSpeed * 1.5f;
 
         CapsuleCollider2D col = arrow.AddComponent<CapsuleCollider2D>();
         col.isTrigger = true;

--- a/Assets/Scripts/PlayerShooter.cs
+++ b/Assets/Scripts/PlayerShooter.cs
@@ -63,17 +63,20 @@ public class PlayerShooter : MonoBehaviour
 
         Vector2 direction = (nearest.transform.position - transform.position).normalized;
 
-        if      (shotgun  != null) shotgun.FireShotgun(direction, projectilePrefab);
-        else if (piercing != null) piercing.FirePiercingArrow(direction);
-        else if (bouncing != null) bouncing.FireBouncingShot(direction);
-        else    FireSingleBullet(direction);
+        if (shotgun != null)
+            shotgun.FireShotgun(direction, projectilePrefab, bouncing, this);
+        else if (piercing != null)
+            piercing.FirePiercingArrow(direction);
+        else if (bouncing != null)
+            bouncing.FireBouncingShot(direction, projectilePrefab, this);
+        else
+            FireSingleBullet(direction);
     }
 
     void FireSingleBullet(Vector2 direction)
     {
         GameObject bullet = Instantiate(projectilePrefab, transform.position, Quaternion.identity);
         ApplyProjectileVisual(bullet, direction);
-
         Rigidbody2D rb = bullet.GetComponent<Rigidbody2D>();
         if (rb != null) rb.linearVelocity = direction * PlayerStats.Instance.projectileSpeed;
     }
@@ -97,7 +100,7 @@ public class PlayerShooter : MonoBehaviour
                     anim.SetFrames(mageFrames);
                 else if (sr != null && mageFireball1 != null)
                     sr.sprite = mageFireball1;
-                float fireAngle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg + 90f;
+                float fireAngle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg - 90f;
                 bullet.transform.rotation = Quaternion.AngleAxis(fireAngle, Vector3.forward);
                 break;
 

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -10,7 +10,9 @@ public class Projectile : MonoBehaviour
     {
         if (!damageSet)
             damage = PlayerStats.Instance.damage;
-        Destroy(gameObject, lifetime);
+
+        if (enabled)
+            Destroy(gameObject, lifetime);
     }
 
     public void SetDamage(float value)

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -4,20 +4,26 @@ public class Projectile : MonoBehaviour
 {
     public float lifetime = 3f;
     private float damage;
+    private bool  damageSet = false;
 
     void Start()
     {
-        damage = PlayerStats.Instance.damage;
+        if (!damageSet)
+            damage = PlayerStats.Instance.damage;
         Destroy(gameObject, lifetime);
+    }
+
+    public void SetDamage(float value)
+    {
+        damage    = value;
+        damageSet = true;
     }
 
     void OnTriggerEnter2D(Collider2D other)
     {
         if (!other.CompareTag("Enemy")) return;
-
         BaseEnemy enemy = other.GetComponent<BaseEnemy>();
         if (enemy != null) enemy.TakeDamage(damage);
-
         Destroy(gameObject);
     }
 }

--- a/Assets/Scripts/ShotgunAbility.cs
+++ b/Assets/Scripts/ShotgunAbility.cs
@@ -2,37 +2,49 @@ using UnityEngine;
 
 public class ShotgunAbility : MonoBehaviour
 {
-    private int bulletCount = 3;
-    private float spreadAngle = 30f;
-    private PlayerShooter shooter;
-
-    void Start()
-    {
-        shooter = GetComponent<PlayerShooter>();
-    }
+    // Damage multiplier on top of PlayerStats.damage
+    // Level 1: 0.8x per bullet (3 bullets = 2.4x total DPS)
+    // Each level adds 0.1x multiplier and 2 more bullets
+    private int   bulletCount     = 3;
+    private float spreadAngle     = 30f;
+    private float damageMultiplier = 0.8f;
 
     public void LevelUp(int level)
     {
-        bulletCount = 3 + (level - 1) * 2;
-        spreadAngle = 30f + (level - 1) * 5f;
+        bulletCount      = 3 + (level - 1) * 2;          // 3, 5, 7, 9...
+        spreadAngle      = 30f + (level - 1) * 5f;        // 30, 35, 40, 45...
+        damageMultiplier = 0.8f + (level - 1) * 0.1f;     // 0.8, 0.9, 1.0, 1.1...
     }
 
-    public void FireShotgun(Vector2 baseDirection, GameObject projectilePrefab)
+    public void FireShotgun(Vector2 baseDirection, GameObject projectilePrefab,
+                            BouncingShotAbility bouncing, PlayerShooter shooter)
     {
-        float startAngle = -spreadAngle / 2f;
-        float angleStep = spreadAngle / (bulletCount - 1);
+        float damage      = PlayerStats.Instance.damage * damageMultiplier;
+        float startAngle  = -spreadAngle / 2f;
+        float angleStep   = bulletCount > 1 ? spreadAngle / (bulletCount - 1) : 0f;
 
         for (int i = 0; i < bulletCount; i++)
         {
-            float angle = startAngle + angleStep * i;
-            Vector2 dir = RotateVector(baseDirection, angle);
+            float   angle = startAngle + angleStep * i;
+            Vector2 dir   = RotateVector(baseDirection, angle);
 
             GameObject bullet = Instantiate(projectilePrefab, transform.position, Quaternion.identity);
-            Rigidbody2D rb = bullet.GetComponent<Rigidbody2D>();
-            rb.linearVelocity = dir * PlayerStats.Instance.projectileSpeed;
 
-            float rot = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg - 90f;
-            bullet.transform.rotation = Quaternion.AngleAxis(rot, Vector3.forward);
+            shooter.ApplyProjectileVisual(bullet, dir);
+
+            Rigidbody2D rb = bullet.GetComponent<Rigidbody2D>();
+            if (rb != null) rb.linearVelocity = dir * PlayerStats.Instance.projectileSpeed;
+
+            if (bouncing != null)
+            {
+                BouncingBullet bb = bullet.AddComponent<BouncingBullet>();
+                bb.Initialize(damage, bouncing.GetBounceCount());
+            }
+            else
+            {
+                Projectile proj = bullet.GetComponent<Projectile>();
+                if (proj != null) proj.SetDamage(damage);
+            }
         }
     }
 

--- a/Assets/Scripts/ShotgunAbility.cs
+++ b/Assets/Scripts/ShotgunAbility.cs
@@ -2,26 +2,23 @@ using UnityEngine;
 
 public class ShotgunAbility : MonoBehaviour
 {
-    // Damage multiplier on top of PlayerStats.damage
-    // Level 1: 0.8x per bullet (3 bullets = 2.4x total DPS)
-    // Each level adds 0.1x multiplier and 2 more bullets
-    private int   bulletCount     = 3;
-    private float spreadAngle     = 30f;
+    private int   bulletCount      = 3;
+    private float spreadAngle      = 30f;
     private float damageMultiplier = 0.8f;
 
     public void LevelUp(int level)
     {
-        bulletCount      = 3 + (level - 1) * 2;          // 3, 5, 7, 9...
-        spreadAngle      = 30f + (level - 1) * 5f;        // 30, 35, 40, 45...
-        damageMultiplier = 0.8f + (level - 1) * 0.1f;     // 0.8, 0.9, 1.0, 1.1...
+        bulletCount      = 3 + (level - 1) * 2;
+        spreadAngle      = 30f + (level - 1) * 5f;
+        damageMultiplier = 0.8f + (level - 1) * 0.1f;
     }
 
     public void FireShotgun(Vector2 baseDirection, GameObject projectilePrefab,
                             BouncingShotAbility bouncing, PlayerShooter shooter)
     {
-        float damage      = PlayerStats.Instance.damage * damageMultiplier;
-        float startAngle  = -spreadAngle / 2f;
-        float angleStep   = bulletCount > 1 ? spreadAngle / (bulletCount - 1) : 0f;
+        float damage     = PlayerStats.Instance.damage * damageMultiplier;
+        float startAngle = -spreadAngle / 2f;
+        float angleStep  = bulletCount > 1 ? spreadAngle / (bulletCount - 1) : 0f;
 
         for (int i = 0; i < bulletCount; i++)
         {
@@ -29,7 +26,6 @@ public class ShotgunAbility : MonoBehaviour
             Vector2 dir   = RotateVector(baseDirection, angle);
 
             GameObject bullet = Instantiate(projectilePrefab, transform.position, Quaternion.identity);
-
             shooter.ApplyProjectileVisual(bullet, dir);
 
             Rigidbody2D rb = bullet.GetComponent<Rigidbody2D>();
@@ -37,6 +33,9 @@ public class ShotgunAbility : MonoBehaviour
 
             if (bouncing != null)
             {
+                Projectile proj = bullet.GetComponent<Projectile>();
+                if (proj != null) proj.enabled = false;
+
                 BouncingBullet bb = bullet.AddComponent<BouncingBullet>();
                 bb.Initialize(damage, bouncing.GetBounceCount());
             }

--- a/Assets/Scripts/UpgradeManager.cs
+++ b/Assets/Scripts/UpgradeManager.cs
@@ -64,7 +64,7 @@ public class UpgradeManager : MonoBehaviour
         switch (upgrade.statToUpgrade)
         {
             case StatType.Damage:          stats.damage          += upgrade.bonusPerLevel; break;
-            case StatType.FireRate:        stats.fireRate        = Mathf.Max(0.05f, stats.fireRate - upgrade.bonusPerLevel); break;
+            case StatType.FireRate:        stats.fireRate        = Mathf.Max(0.15f, stats.fireRate - upgrade.bonusPerLevel); break;
             case StatType.MoveSpeed:       stats.moveSpeed       += upgrade.bonusPerLevel; break;
             case StatType.ProjectileSpeed: stats.projectileSpeed += upgrade.bonusPerLevel; break;
         }

--- a/Assets/Scripts/WaveTable.cs
+++ b/Assets/Scripts/WaveTable.cs
@@ -1,134 +1,81 @@
 using UnityEngine;
 using System.Collections.Generic;
 
-// ═════════════════════════════════════════════════════════════════════════════
-//  SpawnRule  —  one enemy type inside a MinuteWindow
-//  (replaces the old standalone SpawnRule.cs ScriptableObject)
-// ═════════════════════════════════════════════════════════════════════════════
 [System.Serializable]
-public class SpawnRule
+public class WaveEnemyEntry
 {
-    [Tooltip("Enemy prefab — must have a BaseEnemy subclass on it")]
-    public GameObject enemyPrefab;
+    [Tooltip("Enemy prefab for this type")]
+    public GameObject prefab;
 
-    [Range(0f, 100f)]
-    [Tooltip("Higher = more likely to be picked within this window")]
-    public float spawnWeight = 10f;
-
-    [Tooltip("Fire several at once instead of one at a time")]
-    public bool  spawnInClusters = false;
-    public int   minClusterSize  = 3;
-    public int   maxClusterSize  = 8;
-    public float clusterSpread   = 1.5f;
-}
-
-// ═════════════════════════════════════════════════════════════════════════════
-//  MinuteWindow  —  which enemies are active during a time band
-// ═════════════════════════════════════════════════════════════════════════════
-[System.Serializable]
-public class MinuteWindow
-{
-    [Tooltip("Window becomes active at this many seconds into the run")]
-    public float startTime = 0f;
-
-    [Tooltip("Window ends at this many seconds. Set to 0 to run until the end")]
-    public float endTime   = 60f;
-
-    [Tooltip("Label shown in the Inspector only — has no effect on gameplay")]
-    public string label    = "Minute 1";
-
-    public List<SpawnRule> rules = new List<SpawnRule>();
-}
-
-// ═════════════════════════════════════════════════════════════════════════════
-//  SpecialEvent  —  timed interventions that break the normal spawn loop
-// ═════════════════════════════════════════════════════════════════════════════
-public enum SpecialEventType
-{
-    SwarmRush,   // continuous flood from one screen edge for N seconds
-    ArenaRing,   // ring of enemies spawns around the player instantly
-    Stalker,     // one very tanky enemy that never stops following the player
-    WallSpawn,   // ring of tough enemies — the DPS counter-measure
+    [Tooltip("Minimum alive count. Spawner fills to this quota every tick.")]
+    public int minimumAlive = 10;
 }
 
 [System.Serializable]
-public class SpecialEvent
+public class WaveDefinition
 {
-    public SpecialEventType eventType   = SpecialEventType.SwarmRush;
-    public float            triggerTime = 120f;
-    public float            duration    = 30f;
-    public GameObject       enemyPrefab;
-    public int              enemyCount  = 40;
-    public float            ringRadius  = 6f;
+    [Tooltip("Human-readable label — no effect on gameplay")]
+    public string label = "Minute 0";
+
+    [Tooltip("Enemy types active this minute and their minimum alive quotas")]
+    public List<WaveEnemyEntry> enemies = new List<WaveEnemyEntry>();
+
+    [Tooltip("How often (seconds) the spawner checks and fills quotas")]
+    public float spawnInterval = 1.0f;
+}
+
+public enum MapEventType
+{
+    SwarmRush,    // flood from one screen edge
+    WallSpawn,    // ring around the player
+    ArenaRing,    // closing ring
+}
+
+[System.Serializable]
+public class MapEvent
+{
+    public string       label        = "Event";
+    public MapEventType eventType    = MapEventType.SwarmRush;
+
+    [Tooltip("Seconds into the run when this fires (e.g. 150 = minute 2 second 30)")]
+    public float        triggerTime  = 60f;
+
+    public GameObject   enemyPrefab;
+    public int          enemyCount   = 30;
+    public float        ringRadius   = 7f;
+
+    [Tooltip("Duration in seconds (only used for SwarmRush)")]
+    public float        duration     = 20f;
+
     [HideInInspector] public bool triggered = false;
 }
 
 [CreateAssetMenu(fileName = "WaveTable", menuName = "Enemies/Wave Table")]
 public class WaveTable : ScriptableObject
 {
-    [Header("Enemy Cap  (how many can be alive at once)")]
-    public int   startEnemyCap = 60;
-    public int   maxEnemyCap   = 500;
-    [Tooltip("Seconds to grow from startEnemyCap to maxEnemyCap")]
-    public float capRampTime   = 900f;
+    [Header("Hard Cap")]
+    [Tooltip("No regular spawns above this count — mirrors the VS 300 cap")]
+    public int hardCap = 300;
 
-    [Header("Spawn Pulse Speed")]
-    [Tooltip("Seconds between spawn pulses at the very start")]
-    public float baseSpawnInterval = 1.0f;
-    [Tooltip("Fastest the pulse can ever get")]
-    public float minSpawnInterval  = 0.15f;
-    [Tooltip("Seconds for the pulse to reach its fastest")]
-    public float intervalRampTime  = 600f;
-
-    [Header("Stat Scaling  (enemies get tougher over time)")]
-    [Tooltip("HP doubles after this many seconds")]
-    public float hpScaleTime      = 600f;
-    [Tooltip("How much speed grows (fraction of base per scaleTime)")]
-    public float speedScaleFactor = 0.3f;
-    public float speedScaleTime   = 600f;
-    [Tooltip("Damage doubles after this many seconds")]
-    public float damageScaleTime  = 480f;
-
-    [Header("DPS Wall  (fires when the player kills too fast)")]
-    [Tooltip("Kills per second needed to trigger a wall spawn")]
-    public float wallTriggerKillRate = 8f;
-    [Tooltip("Minimum seconds between wall spawns")]
-    public float wallSpawnCooldown   = 20f;
-
-    [Header("Off-Screen Recycling")]
+    [Header("Despawn / Teleport")]
     [Tooltip("Enemies beyond this distance from the player get teleported to the spawn ring")]
     public float despawnDistance      = 22f;
-    [Tooltip("Seconds between teleport scans (lower = more accurate but more CPU)")]
     public float teleportScanInterval = 2f;
 
-    [Header("Minute Windows")]
-    public List<MinuteWindow> windows = new List<MinuteWindow>();
+    [Header("Wave Schedule  (one entry per minute, index 0 = minute 0)")]
+    public List<WaveDefinition> waves = new List<WaveDefinition>();
 
-    [Header("Special Events")]
-    public List<SpecialEvent> specialEvents = new List<SpecialEvent>();
+    [Header("Map Events")]
+    public List<MapEvent> mapEvents = new List<MapEvent>();
 
-    public int GetEnemyCap(float t)
+    public WaveDefinition GetWave(float gameTime)
     {
-        float pct = Mathf.Clamp01(t / capRampTime);
-        return Mathf.RoundToInt(Mathf.Lerp(startEnemyCap, maxEnemyCap, pct));
+        if (waves == null || waves.Count == 0) return null;
+        int index = Mathf.FloorToInt(gameTime / 60f);
+        index = Mathf.Clamp(index, 0, waves.Count - 1);
+        return waves[index];
     }
 
-    public float GetSpawnInterval(float t)
-    {
-        float pct = Mathf.Clamp01(t / intervalRampTime);
-        return Mathf.Lerp(baseSpawnInterval, minSpawnInterval, pct);
-    }
-
-    public float GetHPMultiplier(float t)     => 1f + (t / hpScaleTime);
-    public float GetSpeedMultiplier(float t)  => 1f + (t / speedScaleTime) * speedScaleFactor;
-    public float GetDamageMultiplier(float t) => 1f + (t / damageScaleTime);
-
-    public MinuteWindow GetActiveWindow(float t)
-    {
-        MinuteWindow best = null;
-        foreach (var w in windows)
-            if (t >= w.startTime && (w.endTime <= 0f || t < w.endTime))
-                best = w;
-        return best;
-    }
+    public int GetWaveIndex(float gameTime)
+        => Mathf.Clamp(Mathf.FloorToInt(gameTime / 60f), 0, Mathf.Max(0, waves.Count - 1));
 }


### PR DESCRIPTION
Spawner — replaced simple timer-based spawner with a quota fill loop. Every spawn interval it checks how many of each enemy type are alive and fills to a minimum quota. If already at quota it trickles one of each anyway. Hard cap at 300.

Wave schedule — replaced the 5 manual time-windows with a full 10-minute data-driven table (one WaveDefinition per minute, currently 10 minutes, will probably make it longer in the future), each defining which enemy types are active, their minimum alive quota, and spawn interval. 

HP scaling — replaced time-based HP multipliers with HP × player level at spawn time. Enemies flagged with hpScalesWithLevel get tougher as the player levels up, not just as time passes.

XP curve — replaced flat scaling formula with a three-phase curve. Phase 1 (L1–20): +10 XP per level. Phase 2 (L21–40): +13 XP per level. Phase 3 (L41+): +16 XP per level. 

Map events — timed off-cycle spawns (SwarmRush, WallSpawn) now fire on a fixed schedule defined in the WaveTable instead of reactively based on kill rate